### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All beside the Type are optional. Buffer will be allocated to the struct's size 
 * `new reified('TypeName' || Type, buffer, offset, value)` - Constructs an instance of _‹Type›_ (`<Data>`). `new` is required. 
 * `reified.data('TypeName' || Type, buffer, offset, value)` - Same but doesn't require `new`.
 
-###_‹Type›_ creation
+### _‹Type›_ creation
 
 * _‹ArrayT›_    `reified('Uint8[10]')` - returns an _‹ArrayT›_ for the specified type and size
 * _‹ArrayT›_    `reified('Uint8[10][10][10]')` - arrays can be nested arbitrarily


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
